### PR TITLE
sepolia: add reth-based node compose file

### DIFF
--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -63,6 +63,34 @@ services:
       - ${VERIFIER_AUTH_PORT:-8551}:8551
     healthcheck:
       <<: *healthcheck
+  proxyd:
+    # Sits in front of op-reth. reth only has data from a fixed height onward
+    # (see op-reth's init-state/import-op step above), and some methods
+    # (eth_getProof, debug_trace*) are unreliable on reth regardless of height.
+    # Both cases get forwarded to the public RPC (rpc.sepolia.mantle.xyz)
+    # instead of erroring — see sepolia/proxyd.toml for the exact routing.
+    #
+    # TODO: replace with the publicly downloadable proxyd image/tag once available
+    image: mantlenetworkio/mantle-proxyd:latest
+    pull_policy: always
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1000M
+        reservations:
+          cpus: '250m'
+          memory: 256M
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      op-reth:
+        condition: service_healthy
+    volumes:
+      - ./sepolia/proxyd.toml:/etc/proxyd/proxyd.toml
+    ports:
+      - ${PROXYD_HTTP_PORT:-1545}:8545
+      - ${PROXYD_WS_PORT:-1546}:8546
   op-node:
     image: mantlenetworkio/mantle-op-node:v1.5.3
     pull_policy: always

--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -69,8 +69,7 @@ services:
     # Both cases get forwarded to the public RPC (rpc.sepolia.mantle.xyz)
     # instead of erroring — see sepolia/proxyd.toml for the exact routing.
     #
-    # TODO: replace with the publicly downloadable proxyd image/tag once available
-    image: mantlenetworkio/mantle-proxyd:latest
+    image: mantlenetworkio/mantle-proxyd:v1.0.2
     pull_policy: always
     deploy:
       resources:

--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 x-healthcheck: &healthcheck
-  test: [ "CMD", "nc", "-zv", "-w", "2", "localhost", "8545" ]
+  test: [ "CMD", "bash", "-c", "echo > /dev/tcp/127.0.0.1/8545" ]
   interval: 5s
   timeout: 5s
   retries: 3

--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -1,0 +1,114 @@
+version: '3.4'
+
+x-healthcheck: &healthcheck
+  test: [ "CMD", "nc", "-zv", "-w", "2", "localhost", "8545" ]
+  interval: 5s
+  timeout: 5s
+  retries: 3
+  start_period: 60s
+
+services:
+  op-reth:
+    # TODO: replace with the publicly downloadable reth image/tag once available
+    image: mantlenetworkio/mantle-op-reth:latest
+    pull_policy: always
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 16000M
+        reservations:
+          cpus: '4'
+          memory: 16000M
+      restart_policy:
+        condition: on-failure
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    entrypoint: sh
+    command:
+      - -c
+      - |
+        test -d /db/db || op-reth init --datadir /db --chain /config/genesis.json
+        exec op-reth node \
+          --chain=/config/genesis.json \
+          --datadir=/db \
+          --port=30300 \
+          --metrics=0.0.0.0:9001 \
+          --http \
+          --http.corsdomain=* \
+          --http.addr=0.0.0.0 \
+          --http.port=8545 \
+          --http.api=web3,eth,debug,txpool,net \
+          --ws \
+          --ws.addr=0.0.0.0 \
+          --ws.port=8546 \
+          --ws.origins=* \
+          --ws.api=web3,eth,debug,txpool,net \
+          --txpool.nolocals \
+          --authrpc.addr=0.0.0.0 \
+          --authrpc.port=8551 \
+          --authrpc.jwtsecret=/secret/jwt_secret_txt \
+          --disable-discovery \
+          --rpc.max-blocks-per-filter=0 \
+          --engine.persistence-threshold=0 \
+          --engine.memory-block-buffer-target=0 \
+          --rollup.sequencer-http=https://rpc.sepolia.mantle.xyz
+    volumes:
+      - ./sepolia/secret:/secret/
+      - ./sepolia/genesis.json:/config/genesis.json
+      - ./data/sepolia-reth:/db/
+    ports:
+      - ${VERIFIER_HTTP_PORT:-8545}:8545
+      - ${VERIFIER_WS_PORT:-8546}:8546
+      - ${VERIFIER_AUTH_PORT:-8551}:8551
+    healthcheck:
+      <<: *healthcheck
+  op-node:
+    image: mantlenetworkio/mantle-op-node:v1.5.3
+    pull_policy: always
+    deploy:
+      resources:
+        limits:
+          cpus: '4'
+          memory: 8000M
+        reservations:
+          cpus: '4'
+          memory: 8000M
+      restart_policy:
+        condition: on-failure
+    depends_on:
+      op-reth:
+        condition: service_healthy
+    volumes:
+      - ./sepolia/secret:/secret
+      - ./sepolia/rollup.json:/config/rollup.json
+    environment:
+      OP_NODE_L1_ETH_RPC: $L1_RPC_SEPOLIA
+      OP_NODE_L2_ENGINE_RPC: 'http://op-reth:8551'
+      OP_NODE_L2_ENGINE_AUTH: /secret/jwt_secret_txt
+      OP_NODE_ROLLUP_CONFIG: '/config/rollup.json'
+      OP_NODE_P2P_PRIV_PATH: /secret/p2p_node_key_txt
+      OP_NODE_VERIFIER_L1_CONFS: '3'
+      OP_NODE_RPC_ADDR: '0.0.0.0'
+      OP_NODE_RPC_PORT: 8545
+      OP_NODE_P2P_LISTEN_IP: '0.0.0.0'
+      OP_NODE_P2P_LISTEN_TCP_PORT: 9003
+      OP_NODE_P2P_LISTEN_UDP_PORT: 9003
+      OP_NODE_P2P_PEER_SCORING: 'light'
+      OP_NODE_P2P_PEER_BANNING: 'true'
+      OP_NODE_METRICS_ENABLED: 'true'
+      OP_NODE_METRICS_ADDR: '0.0.0.0'
+      OP_NODE_METRICS_PORT: 7300
+      OP_NODE_PPROF_ENABLED: 'true'
+      OP_NODE_PPROF_PORT: 6060
+      OP_NODE_PPROF_ADDR: '0.0.0.0'
+      OP_NODE_P2P_DISCOVERY_PATH: '/op-node/opnode_discovery_db'
+      OP_NODE_P2P_PEERSTORE_PATH: '/op-node/opnode_peerstore_db'
+      OP_NODE_L2_BACKUP_UNSAFE_SYNC_RPC: https://rpc.sepolia.mantle.xyz
+      OP_NODE_P2P_STATIC: '/dns4/peer0.sepolia.mantle.xyz/tcp/9003/p2p/16Uiu2HAkywYkvLRUH2MXbD6tSoT3jSMAzTWTp1aDijxpXQXxG6VM'
+      OP_NODE_SEQUENCER_ENABLED: 'false'
+      OP_NODE_P2P_AGENT: 'mantle'
+      OP_NODE_P2P_SYNC_REQ_RESP: 'true'
+      OP_NODE_L1_BEACON: $L1_BEACON_SEPOLIA
+    ports:
+      - ${NODE_RPC_PORT:-9545}:8545

--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -9,8 +9,7 @@ x-healthcheck: &healthcheck
 
 services:
   op-reth:
-    # TODO: replace with the publicly downloadable reth image/tag once available
-    image: mantlenetworkio/mantle-op-reth:latest
+    image: mantlenetworkio/mantle-op-reth:op-reth-v2.2.1-mantle-arsia.2
     pull_policy: always
     deploy:
       resources:
@@ -92,7 +91,7 @@ services:
       - ${PROXYD_HTTP_PORT:-1545}:8545
       - ${PROXYD_WS_PORT:-1546}:8546
   op-node:
-    image: mantlenetworkio/mantle-op-node:v1.5.3
+    image: mantlenetworkio/mantle-op-node:v1.6.2
     pull_policy: always
     deploy:
       resources:

--- a/docker-compose-sepolia-reth.yml
+++ b/docker-compose-sepolia-reth.yml
@@ -27,9 +27,9 @@ services:
     command:
       - -c
       - |
-        test -d /db/db || op-reth init --datadir /db --chain /config/genesis.json
+        test -d /db/db || op-reth init --datadir /db --chain mantle-sepolia
         exec op-reth node \
-          --chain=/config/genesis.json \
+          --chain=mantle-sepolia \
           --datadir=/db \
           --port=30300 \
           --metrics=0.0.0.0:9001 \
@@ -42,19 +42,19 @@ services:
           --ws.addr=0.0.0.0 \
           --ws.port=8546 \
           --ws.origins=* \
-          --ws.api=web3,eth,debug,txpool,net \
+          --ws.api=debug,eth,txpool,net \
           --txpool.nolocals \
           --authrpc.addr=0.0.0.0 \
           --authrpc.port=8551 \
           --authrpc.jwtsecret=/secret/jwt_secret_txt \
           --disable-discovery \
           --rpc.max-blocks-per-filter=0 \
+          --min-suggested-priority-fee=100000 \
           --engine.persistence-threshold=0 \
           --engine.memory-block-buffer-target=0 \
           --rollup.sequencer-http=https://rpc.sepolia.mantle.xyz
     volumes:
       - ./sepolia/secret:/secret/
-      - ./sepolia/genesis.json:/config/genesis.json
       - ./data/sepolia-reth:/db/
     ports:
       - ${VERIFIER_HTTP_PORT:-8545}:8545

--- a/run-node-sepolia.md
+++ b/run-node-sepolia.md
@@ -109,6 +109,19 @@ export L1_BEACON_SEPOLIA='https://eth-beacon-chain-sepolia.drpc.org/rest/'  #ple
 docker-compose -f docker-compose-sepolia-upgrade-beacon.yml up -d 
 ```
 
+#### 4.3 Start a reth-based node (alternative execution client)
+
+If you'd rather run [reth](https://github.com/paradigmxyz/reth) instead of op-geth as the execution client, use `docker-compose-sepolia-reth.yml`. It uses the L1 beacon chain to pull data for the rollup node (same as 4.2), so you need `L1_RPC_SEPOLIA` and `L1_BEACON_SEPOLIA` set the same way.
+
+```
+export L1_RPC_SEPOLIA='https://rpc.ankr.com/eth_sepolia'  #please replace
+export L1_BEACON_SEPOLIA='https://eth-beacon-chain-sepolia.drpc.org/rest/'  #please replace
+
+docker-compose -f docker-compose-sepolia-reth.yml up -d 
+```
+
+By default this initializes reth from genesis and fully syncs via L1 derivation, which takes considerably longer than starting op-geth from a snapshot (step 3). If a downloadable reth snapshot/image becomes available, restore it into `./data/sepolia-reth` before the first `up -d` to skip the full sync.
+
 ## Check Installation Result
 
 Follow these steps to check if the installation is successful

--- a/run-node-sepolia.md
+++ b/run-node-sepolia.md
@@ -113,14 +113,38 @@ docker-compose -f docker-compose-sepolia-upgrade-beacon.yml up -d
 
 If you'd rather run [reth](https://github.com/paradigmxyz/reth) instead of op-geth as the execution client, use `docker-compose-sepolia-reth.yml`. It uses the L1 beacon chain to pull data for the rollup node (same as 4.2), so you need `L1_RPC_SEPOLIA` and `L1_BEACON_SEPOLIA` set the same way.
 
+reth only starts from a snapshot — there's no genesis-sync path, so restore one into `./data/sepolia-reth` before the first `up -d`:
+
+```
+mkdir -p ./data/sepolia-reth
+
+# Snapshots are produced weekly; there's no "latest" pointer yet, so probe back a few days
+for i in 0 1 2 3 4 5 6; do
+  SEPOLIA_RETH_TARBALL_DATE=$(date -u -d "-${i} day" +%Y%m%d 2>/dev/null || date -u -v-${i}d +%Y%m%d)
+  CODE=$(curl -s -o /dev/null -w '%{http_code}' https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst)
+  [ "$CODE" = "200" ] && break
+done
+echo "Using snapshot date: ${SEPOLIA_RETH_TARBALL_DATE}"
+
+# Download tarball
+wget -c https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst
+
+# Then you can verify your download
+SEPOLIA_RETH_TARBALL_CHECKSUM=`curl https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth-checksum.tmp | awk '{print $1}'`
+echo "${SEPOLIA_RETH_TARBALL_CHECKSUM} *${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst" | shasum -a 256 --check
+
+# Unzip snapshot to the ledger path
+tar --use-compress-program=unzstd -xvf ${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst -C ./data/sepolia-reth
+```
+
+Then bring the stack up:
+
 ```
 export L1_RPC_SEPOLIA='https://rpc.ankr.com/eth_sepolia'  #please replace
 export L1_BEACON_SEPOLIA='https://eth-beacon-chain-sepolia.drpc.org/rest/'  #please replace
 
 docker-compose -f docker-compose-sepolia-reth.yml up -d 
 ```
-
-By default this initializes reth from genesis and fully syncs via L1 derivation, which takes considerably longer than starting op-geth from a snapshot (step 3). If a downloadable reth snapshot/image becomes available, restore it into `./data/sepolia-reth` before the first `up -d` to skip the full sync.
 
 **Query through the `proxyd` service, not `op-reth` directly** (`${PROXYD_HTTP_PORT:-1545}` / `${PROXYD_WS_PORT:-1546}` on the host, default `http://localhost:1545`). reth only has chain data from a fixed height onward (see the `init-state`/`import-op` step in `docker-compose-sepolia-reth.yml`), and a few methods (`eth_getProof`, `debug_trace*`) are unreliable on reth regardless of height. `proxyd` forwards both cases to the public RPC (`rpc.sepolia.mantle.xyz`) instead of failing locally — see `sepolia/proxyd.toml` for the exact routing rules. Querying `op-reth`'s own port directly (`${VERIFIER_HTTP_PORT:-8545}`) skips this fallback and will error on pre-cutoff blocks or those methods.
 

--- a/run-node-sepolia.md
+++ b/run-node-sepolia.md
@@ -118,19 +118,12 @@ reth only starts from a snapshot — there's no genesis-sync path, so restore on
 ```
 mkdir -p ./data/sepolia-reth
 
-# Snapshots are produced weekly; there's no "latest" pointer yet, so probe back a few days
-for i in 0 1 2 3 4 5 6; do
-  SEPOLIA_RETH_TARBALL_DATE=$(date -u -d "-${i} day" +%Y%m%d 2>/dev/null || date -u -v-${i}d +%Y%m%d)
-  CODE=$(curl -s -o /dev/null -w '%{http_code}' https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst)
-  [ "$CODE" = "200" ] && break
-done
-echo "Using snapshot date: ${SEPOLIA_RETH_TARBALL_DATE}"
-
-# Download tarball
+# Download the latest official snapshot
+SEPOLIA_RETH_TARBALL_DATE=`curl https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/current-reth.info`
 wget -c https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst
 
 # Then you can verify your download
-SEPOLIA_RETH_TARBALL_CHECKSUM=`curl https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth-checksum.tmp | awk '{print $1}'`
+SEPOLIA_RETH_TARBALL_CHECKSUM=`curl https://s3.ap-southeast-1.amazonaws.com/snapshot.sepolia.mantle.xyz/${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst.sha256sum | awk '{print $1}'`
 echo "${SEPOLIA_RETH_TARBALL_CHECKSUM} *${SEPOLIA_RETH_TARBALL_DATE}-sepolia-reth.tar.zst" | shasum -a 256 --check
 
 # Unzip snapshot to the ledger path

--- a/run-node-sepolia.md
+++ b/run-node-sepolia.md
@@ -122,6 +122,8 @@ docker-compose -f docker-compose-sepolia-reth.yml up -d
 
 By default this initializes reth from genesis and fully syncs via L1 derivation, which takes considerably longer than starting op-geth from a snapshot (step 3). If a downloadable reth snapshot/image becomes available, restore it into `./data/sepolia-reth` before the first `up -d` to skip the full sync.
 
+**Query through the `proxyd` service, not `op-reth` directly** (`${PROXYD_HTTP_PORT:-1545}` / `${PROXYD_WS_PORT:-1546}` on the host, default `http://localhost:1545`). reth only has chain data from a fixed height onward (see the `init-state`/`import-op` step in `docker-compose-sepolia-reth.yml`), and a few methods (`eth_getProof`, `debug_trace*`) are unreliable on reth regardless of height. `proxyd` forwards both cases to the public RPC (`rpc.sepolia.mantle.xyz`) instead of failing locally — see `sepolia/proxyd.toml` for the exact routing rules. Querying `op-reth`'s own port directly (`${VERIFIER_HTTP_PORT:-8545}`) skips this fallback and will error on pre-cutoff blocks or those methods.
+
 ## Check Installation Result
 
 Follow these steps to check if the installation is successful

--- a/sepolia/proxyd.toml
+++ b/sepolia/proxyd.toml
@@ -6,10 +6,73 @@
 # height. A handful of methods (eth_getProof, debug_trace*) are also heavier/less
 # reliable on reth for old data. Both cases are forwarded to the public RPC
 # (rpc.sepolia.mantle.xyz) instead of failing locally.
+#
+# Every other method op-reth exposes (web3/eth/debug/txpool/net, matching
+# --http.api on op-reth) is whitelisted below and goes straight to local reth —
+# proxyd only exists here to handle the two cases above, not to gatekeep methods.
 ws_method_whitelist = [
   "eth_subscribe",
+  "eth_unsubscribe",
+  "web3_clientVersion",
+  "web3_sha3",
+  "net_version",
+  "net_listening",
+  "net_peerCount",
   "eth_chainId",
-  "eth_unsubscribe"
+  "eth_syncing",
+  "eth_gasPrice",
+  "eth_maxPriorityFeePerGas",
+  "eth_feeHistory",
+  "eth_blockNumber",
+  "eth_getBalance",
+  "eth_getStorageAt",
+  "eth_getTransactionCount",
+  "eth_getCode",
+  "eth_getBlockByHash",
+  "eth_getBlockByNumber",
+  "eth_getHeaderByHash",
+  "eth_getHeaderByNumber",
+  "eth_getBlockRange",
+  "eth_getBlockTransactionCountByHash",
+  "eth_getBlockTransactionCountByNumber",
+  "eth_getUncleCountByBlockHash",
+  "eth_getUncleCountByBlockNumber",
+  "eth_getUncleByBlockHashAndIndex",
+  "eth_getUncleByBlockNumberAndIndex",
+  "eth_getBlockReceipts",
+  "eth_getTransactionByHash",
+  "eth_getTransactionByBlockHashAndIndex",
+  "eth_getTransactionByBlockNumberAndIndex",
+  "eth_getTransactionReceipt",
+  "eth_getRawTransactionByHash",
+  "eth_getRawTransactionByBlockHashAndIndex",
+  "eth_getRawTransactionByBlockNumberAndIndex",
+  "eth_getLogs",
+  "eth_newFilter",
+  "eth_newBlockFilter",
+  "eth_newPendingTransactionFilter",
+  "eth_getFilterChanges",
+  "eth_getFilterLogs",
+  "eth_uninstallFilter",
+  "eth_call",
+  "eth_estimateGas",
+  "eth_createAccessList",
+  "eth_sendRawTransaction",
+  "eth_sendRawTransactionWithPreconf",
+  "eth_estimateTotalFee",
+  "eth_getProof",
+  "debug_getRawBlock",
+  "debug_getRawHeader",
+  "debug_getRawReceipts",
+  "debug_getRawTransaction",
+  "debug_traceCall",
+  "debug_traceTransaction",
+  "debug_traceBlockByNumber",
+  "debug_traceBlockByHash",
+  "txpool_status",
+  "txpool_content",
+  "txpool_contentFrom",
+  "txpool_inspect",
 ]
 ws_backend_group = "main"
 
@@ -60,15 +123,23 @@ debug_getRawReceipts = 0
 [backend_groups.fallback_only]
 backends = ["fallback"]
 
-# Mapping of methods to backend groups. Everything defaults to "main" (local reth,
-# height-routed to fallback for pre-cutoff blocks); eth_getProof/debug_trace* always
-# go to fallback_only since reth is unreliable/slow for these regardless of height.
+# Mapping of methods to backend groups. Everything op-reth exposes (per its
+# --http.api=web3,eth,debug,txpool,net flag) is whitelisted here and defaults to
+# "main" (local reth, height-routed to fallback for pre-cutoff blocks);
+# eth_getProof/debug_trace* always go to fallback_only since reth is
+# unreliable/slow for these regardless of height. Nothing is blocked beyond that —
+# if op-reth doesn't support a method it'll error from reth itself, not proxyd.
 [rpc_method_mappings]
 eth_blockNumber = "main"
 eth_getBlockByNumber = "main"
 eth_getBlockByHash = "main"
 eth_getBlockTransactionCountByNumber = "main"
 eth_getBlockTransactionCountByHash = "main"
+eth_getUncleCountByBlockHash = "main"
+eth_getUncleCountByBlockNumber = "main"
+eth_getUncleByBlockHashAndIndex = "main"
+eth_getUncleByBlockNumberAndIndex = "main"
+eth_getBlockRange = "main"
 eth_getHeaderByNumber = "main"
 eth_getHeaderByHash = "main"
 eth_getBlockReceipts = "main"
@@ -78,8 +149,13 @@ eth_getTransactionCount = "main"
 eth_getTransactionByHash = "main"
 eth_getTransactionReceipt = "main"
 eth_getRawTransactionByHash = "main"
+eth_getRawTransactionByBlockHashAndIndex = "main"
+eth_getRawTransactionByBlockNumberAndIndex = "main"
 eth_call = "main"
+eth_createAccessList = "main"
 eth_sendRawTransaction = "main"
+eth_sendRawTransactionWithPreconf = "main"
+eth_estimateTotalFee = "main"
 eth_getBalance = "main"
 eth_getProof = "fallback_only"
 eth_getCode = "main"
@@ -95,6 +171,7 @@ eth_subscribe = "main"
 eth_unsubscribe = "main"
 eth_chainId = "main"
 net_listening = "main"
+net_peerCount = "main"
 eth_syncing = "main"
 net_version = "main"
 eth_estimateGas = "main"
@@ -103,6 +180,10 @@ eth_maxPriorityFeePerGas = "main"
 eth_feeHistory = "main"
 web3_clientVersion = "main"
 web3_sha3 = "main"
+txpool_status = "main"
+txpool_content = "main"
+txpool_contentFrom = "main"
+txpool_inspect = "main"
 # JS tracer BigInteger.js polyfill gaps on reth — see docs/geth-fork-handling notes internally.
 debug_traceCall = "fallback_only"
 debug_traceTransaction = "fallback_only"
@@ -111,3 +192,4 @@ debug_traceBlockByHash = "fallback_only"
 debug_getRawBlock = "main"
 debug_getRawHeader = "main"
 debug_getRawReceipts = "main"
+debug_getRawTransaction = "main"

--- a/sepolia/proxyd.toml
+++ b/sepolia/proxyd.toml
@@ -1,0 +1,113 @@
+#####
+# Sits in front of a local reth node.
+#
+# reth is bootstrapped from a fixed height (see docker-compose-sepolia-reth.yml's
+# init-state/import-op step) rather than genesis, so it has no data below that
+# height. A handful of methods (eth_getProof, debug_trace*) are also heavier/less
+# reliable on reth for old data. Both cases are forwarded to the public RPC
+# (rpc.sepolia.mantle.xyz) instead of failing locally.
+ws_method_whitelist = [
+  "eth_subscribe",
+  "eth_chainId",
+  "eth_unsubscribe"
+]
+ws_backend_group = "main"
+
+[server]
+rpc_host = "0.0.0.0"
+rpc_port = 8545
+ws_host = "0.0.0.0"
+ws_port = 8546
+max_body_size_bytes = 10485760
+max_concurrent_rpcs = 1000
+log_level = "info"
+
+[metrics]
+enabled = true
+host = "0.0.0.0"
+port = 9761
+
+[backends]
+[backends.local]
+# op-reth is the service name in docker-compose-sepolia-reth.yml
+rpc_url = "http://op-reth:8545"
+ws_url = "ws://op-reth:8546"
+max_rps = 100
+max_ws_conns = 50
+
+[backends.fallback]
+rpc_url = "https://rpc.sepolia.mantle.xyz"
+max_rps = 20
+
+[backend_groups]
+[backend_groups.main]
+backends = ["local", "fallback"]
+[backend_groups.main.height_based_routing]
+enabled = true
+# reth has no data below this height (see the init-state/import-op step) — anything
+# older is forwarded to the public RPC instead of erroring.
+cutoff_height = 36000000
+primary_backend = "local"
+fallback_backend = "fallback"
+[backend_groups.main.height_based_routing.method_config]
+eth_getBlockReceipts = 0 # first parameter is block number
+debug_traceBlockByNumber = 0
+debug_traceCall = 1
+debug_getRawBlock = 0
+debug_getRawHeader = 0
+debug_getRawReceipts = 0
+
+[backend_groups.fallback_only]
+backends = ["fallback"]
+
+# Mapping of methods to backend groups. Everything defaults to "main" (local reth,
+# height-routed to fallback for pre-cutoff blocks); eth_getProof/debug_trace* always
+# go to fallback_only since reth is unreliable/slow for these regardless of height.
+[rpc_method_mappings]
+eth_blockNumber = "main"
+eth_getBlockByNumber = "main"
+eth_getBlockByHash = "main"
+eth_getBlockTransactionCountByNumber = "main"
+eth_getBlockTransactionCountByHash = "main"
+eth_getHeaderByNumber = "main"
+eth_getHeaderByHash = "main"
+eth_getBlockReceipts = "main"
+eth_getTransactionByBlockHashAndIndex = "main"
+eth_getTransactionByBlockNumberAndIndex = "main"
+eth_getTransactionCount = "main"
+eth_getTransactionByHash = "main"
+eth_getTransactionReceipt = "main"
+eth_getRawTransactionByHash = "main"
+eth_call = "main"
+eth_sendRawTransaction = "main"
+eth_getBalance = "main"
+eth_getProof = "fallback_only"
+eth_getCode = "main"
+eth_getStorageAt = "main"
+eth_getLogs = "main"
+eth_newFilter = "main"
+eth_newBlockFilter = "main"
+eth_newPendingTransactionFilter = "main"
+eth_getFilterLogs = "main"
+eth_getFilterChanges = "main"
+eth_uninstallFilter = "main"
+eth_subscribe = "main"
+eth_unsubscribe = "main"
+eth_chainId = "main"
+net_listening = "main"
+eth_syncing = "main"
+net_version = "main"
+eth_estimateGas = "main"
+eth_gasPrice = "main"
+eth_maxPriorityFeePerGas = "main"
+eth_feeHistory = "main"
+web3_clientVersion = "main"
+web3_sha3 = "main"
+# JS tracer BigInteger.js polyfill gaps on reth — see docs/geth-fork-handling notes internally.
+debug_traceCall = "fallback_only"
+debug_traceTransaction = "fallback_only"
+debug_traceBlockByNumber = "fallback_only"
+debug_traceBlockByHash = "fallback_only"
+debug_getRawBlock = "main"
+debug_getRawHeader = "main"
+debug_getRawReceipts = "main"


### PR DESCRIPTION
## Summary
- Adds `docker-compose-sepolia-reth.yml` as an alternative to op-geth for running a sepolia verifier node, using reth as the execution client
- op-reth uses its built-in `mantle-sepolia` chainspec (`--chain=mantle-sepolia`), same as the production reth-rpc41 setup — no external genesis.json needed
- Adds a `proxyd` service in front of `op-reth`: reth only has data from a fixed height onward (`init-state`/`import-op`), and `eth_getProof`/`debug_trace*` are unreliable on it regardless of height — `proxyd` forwards both cases to the public RPC (`rpc.sepolia.mantle.xyz`) instead of failing locally. Every other method op-reth exposes (web3/eth/debug/txpool/net) is whitelisted and goes straight to local reth — proxyd only exists to handle those two cases, not to gatekeep methods. Routing rules live in `sepolia/proxyd.toml`.
- Adds a "4.3" section to `run-node-sepolia.md` covering the compose file, downloading the reth snapshot (required — there's no genesis-sync path), and pointing operators at `proxyd`'s port (not `op-reth`'s own port) for queries

## Verified
- Ran end to end on a real box with a downloaded snapshot: op-reth starts clean (no genesis mismatch), op-node derives from L1 and keeps inserting new unsafe L2 blocks, `proxyd`/`op-reth` both answer `eth_blockNumber` consistently
- `op-reth`/`op-node`/`proxyd` images are real, publicly pullable tags (no more placeholders)
- Reth snapshot is confirmed publicly downloadable from the same S3 bucket as the geth snapshot; there's now a `current-reth.info` pointer (same pattern as geth's `current.info`) so the doc reads the latest verified date directly instead of probing
- Exposed the stack publicly for QA to test against; QA feedback surfaced that most non-core methods (`net_peerCount`, `txpool_*`, `debug_getRawTransaction`, `eth_getBlockRange`, etc.) were being rejected with "method not whitelisted" — `proxyd` only allowed a small curated subset. Expanded `sepolia/proxyd.toml`'s whitelist to the full method surface op-reth actually serves; re-verified the previously-rejected methods now return correct data end to end.

## Test plan
- [x] Confirm the real public reth and proxyd image/tags to use
- [x] Confirm a downloadable reth snapshot exists and document how to fetch it
- [x] Run `docker-compose -f docker-compose-sepolia-reth.yml up -d` end to end and verify it syncs (checked via `optimism_syncStatus` and rising `unsafe_l2`)
- [x] Verify `proxyd` forwards pre-cutoff-height queries and `eth_getProof`/`debug_trace*` to the public RPC, and everything else to local reth
- [x] Verify the full RPC method surface (not just a curated subset) works through `proxyd` for external users